### PR TITLE
Fixing Task subscription to topics with null and empty permissions

### DIFF
--- a/BaboonFramework/src/org/unc/lac/baboon/main/BaboonConfig.java
+++ b/BaboonFramework/src/org/unc/lac/baboon/main/BaboonConfig.java
@@ -92,16 +92,17 @@ public class BaboonConfig {
         Method method;
         try {
             method = MethodDictionary.getMethod(object, methodName);
-            if (method.isAnnotationPresent(HappeningHandler.class)){
+            if (method.isAnnotationPresent(HappeningHandler.class)) {
                 if (subscriptionsMap.putIfAbsent(new HappeningHandlerObject(object, method), topic) != null) {
-                    throw new NotSubscribableException(
-                            "The happening handler is already subscribed to a topic.");
+                    throw new NotSubscribableException("The happening handler is already subscribed to a topic.");
                 }
-            }
-            else if(method.isAnnotationPresent(Task.class)) {
-                if (subscriptionsMap.putIfAbsent(new TaskObject(object, method), topic) != null) {
-                    throw new NotSubscribableException(
-                            "The task is already subscribed to a topic.");
+            } else if (method.isAnnotationPresent(Task.class)) {
+                if (topic.getPermission() == null) {
+                    throw new NotSubscribableException("The topic's permission could not be empty.");
+                } else if (topic.getPermission().isEmpty()) {
+                    throw new NotSubscribableException("The topic's permission could not be null.");
+                } else if (subscriptionsMap.putIfAbsent(new TaskObject(object, method), topic) != null) {
+                    throw new NotSubscribableException("The task is already subscribed to a topic.");
                 }
             } else {
                 throw new NotSubscribableException();

--- a/BaboonFramework/src/org/unc/lac/baboon/main/BaboonConfig.java
+++ b/BaboonFramework/src/org/unc/lac/baboon/main/BaboonConfig.java
@@ -81,13 +81,13 @@ public class BaboonConfig {
     public void subscribeToTopic(String topicName, Object object, String methodName) throws NotSubscribableException {
         Topic topic = getTopicByName(topicName);
         if (topicName == null || topic == null) {
-            throw new NotSubscribableException("Can Not subscribe to a null topic");
+            throw new NotSubscribableException("Cannot subscribe to a null topic");
         }
         if (object == null) {
-            throw new NotSubscribableException("Can Not subscribe a null object");
+            throw new NotSubscribableException("Cannot subscribe a null object");
         }
         if (methodName == null) {
-            throw new NotSubscribableException("Can Not subscribe a null method name");
+            throw new NotSubscribableException("Cannot subscribe a null method name");
         }
         Method method;
         try {
@@ -98,9 +98,9 @@ public class BaboonConfig {
                 }
             } else if (method.isAnnotationPresent(Task.class)) {
                 if (topic.getPermission() == null) {
-                    throw new NotSubscribableException("The topic's permission could not be empty.");
+                    throw new NotSubscribableException("The topic's permission cannot be empty.");
                 } else if (topic.getPermission().isEmpty()) {
-                    throw new NotSubscribableException("The topic's permission could not be null.");
+                    throw new NotSubscribableException("The topic's permission cannot be null.");
                 } else if (subscriptionsMap.putIfAbsent(new TaskObject(object, method), topic) != null) {
                     throw new NotSubscribableException("The task is already subscribed to a topic.");
                 }

--- a/BaboonFramework/test/org/unc/lac/baboon/test/cases/TasksAndHappeningHandlersSubscriptionTest.java
+++ b/BaboonFramework/test/org/unc/lac/baboon/test/cases/TasksAndHappeningHandlersSubscriptionTest.java
@@ -18,6 +18,7 @@ import org.unc.lac.baboon.utils.MethodDictionary;
 
 public class TasksAndHappeningHandlersSubscriptionTest {
     private final String topicsPath02 = "test/org/unc/lac/baboon/test/resources/topics02.json";
+    private final String topicsPath03 = "test/org/unc/lac/baboon/test/resources/topics03.json";
     private final String[] topicNamesDefined = { "topic1", "topic2", "topic3" };
 
     /**
@@ -29,9 +30,9 @@ public class TasksAndHappeningHandlersSubscriptionTest {
      * {@link HappeningHandler} annotated method to a {@link Topic}</li>
      * <li>Then the {@link HappeningHandlerObject} subscriptions Map should
      * contain a {@link HappeningHandlerObject} with the object instance and the
-     * method subscribed as a map's key</li> And the
-     * {@link HappeningHandlerObject} subscriptions Map should contain the
-     * {@link Topic} as value for the key</li>
+     * method subscribed as a map's key</li>
+     * <li>And the {@link HappeningHandlerObject} subscriptions Map should
+     * contain the {@link Topic} as value for the key</li>
      */
     @Test
     public void subscribingAnExistingHappeningHandlerToAnExistingTopicShouldGetRegisteredInConfigTest() {
@@ -71,8 +72,9 @@ public class TasksAndHappeningHandlersSubscriptionTest {
      * annotated method to a {@link Topic}</li>
      * <li>Then the {@link TaskObject} subscriptions Map should contain a
      * {@link TaskObject} with the object instance and the method subscribed as
-     * a map's key</li> And the {@link TaskObject} subscriptions Map should
-     * contain the {@link Topic} as value for the key</li>
+     * a map's key</li>
+     * <li>And the {@link TaskObject} subscriptions Map should contain the
+     * {@link Topic} as value for the key</li>
      */
     @Test
     public void subscribingAnExistingTaskToAnExistingTopicShouldShouldGetRegisteredInConfigTest() {
@@ -388,6 +390,150 @@ public class TasksAndHappeningHandlersSubscriptionTest {
             fail("Exception should have been thrown before this point");
         } catch (Exception e) {
             assertEquals(NotSubscribableException.class, e.getClass());
+        }
+    }
+
+    /**
+     * <li>Given I have a topics json file containing a topic with name
+     * "topic1"</li>
+     * <li>And topic1 has an empty permission string</li>
+     * <li>And I add the topics configuration to the Framework</li>
+     * <li>When I subscribe a {@link TaskObject} to topic1</li>
+     * <li>Then a {@link NotSubscribableException} exception should be
+     * thrown</li>
+     */
+    @Test
+    public void subscribingTaskToTopicWithEmptyPermissionShouldNotBePossibleTest() {
+        final MockController mockController = new MockController();
+        final String taskMethod = "mockTask";
+        final BaboonConfig baboonConfig = new BaboonConfig();
+        try {
+            baboonConfig.addTopics(topicsPath03);
+        } catch (BadTopicsJsonFormat e) {
+            fail(e.getMessage());
+        } catch (NoTopicsJsonFileException e) {
+            fail(e.getMessage());
+        }
+        try {
+            assertEquals("", baboonConfig.getTopicByName(topicNamesDefined[0]).getPermission());
+            baboonConfig.subscribeToTopic(topicNamesDefined[0], mockController, taskMethod);
+            fail("Exception should have been thrown before this point");
+        } catch (Exception e) {
+            assertEquals(NotSubscribableException.class, e.getClass());
+        }
+    }
+
+    /**
+     * <li>Given I have a topics json file containing a topic with name
+     * "topic2"</li>
+     * <li>And topic2 has not the permission field</li>
+     * <li>And I add the topics configuration to the Framework</li>
+     * <li>When I subscribe a {@link TaskObject} to topic2</li>
+     * <li>Then a {@link NotSubscribableException} exception should be
+     * thrown</li>
+     */
+    @Test
+    public void subscribingTaskToTopicWithNullPermissionShouldNotBePossibleTest() {
+        final MockController mockController = new MockController();
+        final String taskMethod = "mockTask";
+        final BaboonConfig baboonConfig = new BaboonConfig();
+        try {
+            baboonConfig.addTopics(topicsPath03);
+        } catch (BadTopicsJsonFormat e) {
+            fail(e.getMessage());
+        } catch (NoTopicsJsonFileException e) {
+            fail(e.getMessage());
+        }
+        try {
+            assertEquals(null, baboonConfig.getTopicByName(topicNamesDefined[1]).getPermission());
+            baboonConfig.subscribeToTopic(topicNamesDefined[1], mockController, taskMethod);
+            fail("Exception should have been thrown before this point");
+        } catch (Exception e) {
+            assertEquals(NotSubscribableException.class, e.getClass());
+        }
+    }
+
+    /**
+     * <li>Given I have a topics json file containing a topic with name
+     * "topic1"</li>
+     * <li>And topic1 has an empty permission string</li>
+     * <li>And I add the topics configuration to the Framework</li>
+     * <li>When I subscribe a {@link HappeningHandlerObject} to topic1</li>
+     * <li>Then the {@link HappeningHandlerObject} subscriptions Map should
+     * contain a {@link HappeningHandlerObject} with the object instance and the
+     * method subscribed as a map's key</li>
+     * <li>And the {@link HappeningHandlerObject} subscriptions Map should
+     * contain the {@link Topic} as value for the key</li>
+     */
+    @Test
+    public void subscribingHappeningHandlerToTopicWithEmptyPermissionShouldGetRegisteredInConfigTest() {
+        final MockController mockController = new MockController();
+        final String happeningHandlerMethod = "mockHappeningHandler";
+        final BaboonConfig baboonConfig = new BaboonConfig();
+        try {
+            baboonConfig.addTopics(topicsPath03);
+        } catch (BadTopicsJsonFormat e) {
+            fail(e.getMessage());
+        } catch (NoTopicsJsonFileException e) {
+            fail(e.getMessage());
+        }
+        try {
+            assertEquals("", baboonConfig.getTopicByName(topicNamesDefined[0]).getPermission());
+            baboonConfig.subscribeToTopic(topicNamesDefined[0], mockController, happeningHandlerMethod);
+            Map<AbstractTask, Topic> subscriptionsMap = baboonConfig.getSubscriptionsUnmodifiableMap();
+            HappeningHandlerObject testHHO = new HappeningHandlerObject(mockController,
+                    MethodDictionary.getMethod(mockController, happeningHandlerMethod));
+            assertEquals(1, subscriptionsMap.size());
+            assertTrue(subscriptionsMap.keySet().contains(testHHO));
+            assertEquals(topicNamesDefined[0], subscriptionsMap.get(testHHO).getName());
+        } catch (NotSubscribableException e) {
+            fail(e.getMessage());
+        } catch (NoSuchMethodException e) {
+            fail(e.getMessage());
+        } catch (SecurityException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
+     * <li>Given I have a topics json file containing a topic with name
+     * "topic2"</li>
+     * <li>And topic2 has not the permission field</li>
+     * <li>And I add the topics configuration to the Framework</li>
+     * <li>When I subscribe a {@link HappeningHandlerObject} to topic2</li>
+     * <li>Then the {@link HappeningHandlerObject} subscriptions Map should
+     * contain a {@link HappeningHandlerObject} with the object instance and the
+     * method subscribed as a map's key</li>
+     * <li>And the {@link HappeningHandlerObject} subscriptions Map should
+     * contain the {@link Topic} as value for the key</li>
+     */
+    @Test
+    public void subscribingHappeningHandlerToTopicWithNullPermissionShouldGetRegisteredInConfigTest() {
+        final MockController mockController = new MockController();
+        final String happeningHandlerMethod = "mockHappeningHandler";
+        final BaboonConfig baboonConfig = new BaboonConfig();
+        try {
+            baboonConfig.addTopics(topicsPath03);
+        } catch (BadTopicsJsonFormat e) {
+            fail(e.getMessage());
+        } catch (NoTopicsJsonFileException e) {
+            fail(e.getMessage());
+        }
+        try {
+            assertEquals(null, baboonConfig.getTopicByName(topicNamesDefined[1]).getPermission());
+            baboonConfig.subscribeToTopic(topicNamesDefined[1], mockController, happeningHandlerMethod);
+            Map<AbstractTask, Topic> subscriptionsMap = baboonConfig.getSubscriptionsUnmodifiableMap();
+            HappeningHandlerObject testHHO = new HappeningHandlerObject(mockController,
+                    MethodDictionary.getMethod(mockController, happeningHandlerMethod));
+            assertEquals(1, subscriptionsMap.size());
+            assertTrue(subscriptionsMap.keySet().contains(testHHO));
+            assertEquals(topicNamesDefined[1], subscriptionsMap.get(testHHO).getName());
+        } catch (NotSubscribableException e) {
+            fail(e.getMessage());
+        } catch (NoSuchMethodException e) {
+            fail(e.getMessage());
+        } catch (SecurityException e) {
+            fail(e.getMessage());
         }
     }
 

--- a/BaboonFramework/test/org/unc/lac/baboon/test/resources/topics03.json
+++ b/BaboonFramework/test/org/unc/lac/baboon/test/resources/topics03.json
@@ -1,0 +1,11 @@
+[
+	{
+	"name":"topic1",
+	"permission":"",
+	"fireCallback":["t1"]
+	},
+    {
+    "name":"topic2",
+    "fireCallback":["t1"]
+    }
+]


### PR DESCRIPTION
Now when trying to subscribe a task to topics with null and empty permission an exception is thrown.
Happening handler subscription to this topics is possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juanjoarce7456/petri_event_dispatcher/15)
<!-- Reviewable:end -->
